### PR TITLE
Fix download url

### DIFF
--- a/Model/Download.php
+++ b/Model/Download.php
@@ -62,7 +62,7 @@ class Download extends AbstractModel implements IdentityInterface
     /**
      * @var string
      */
-    private $uploadFolder = 'sebwite/productdownloads/';
+    private $uploadFolder = 'sebwite/productdownloads';
 
     public function __construct(FilterManager $filter, Context $context, Registry $registry, AbstractResource $resource = null, AbstractDb $resourceCollection = null, array $data = [])
     {
@@ -101,7 +101,7 @@ class Download extends AbstractModel implements IdentityInterface
      */
     public function getUrl($download)
     {
-        return 'pub/media/' . $this->uploadFolder . $download['download_url'];
+        return 'media/' . $this->uploadFolder . $download['download_url'];
     }
 
     /**


### PR DESCRIPTION
1: The download url is saved in DB with a starting slash so $uploadFolder= 'sebwite/productdownloads' does not require an ending slash (L65)
2: The pub directory is not accessible with every server configuration, so remove it in the url generation (L104)